### PR TITLE
Allow selective deleting of orders

### DIFF
--- a/Components/MyOrder/DeleteOrder.razor
+++ b/Components/MyOrder/DeleteOrder.razor
@@ -1,0 +1,61 @@
+@using GroupOrder.Data
+@using GroupOrder.Services.Common
+@inject IGroupService gs
+
+@if (CanEdit())
+{
+    <a style="padding: 0;" title="Delete order" @onclick="Delete">
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" class="bi bi-trash" viewBox="0 0 16 16">
+            <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0z"/>
+            <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4zM2.5 3h11V2h-11z"/>
+        </svg>
+    </a>
+}
+
+@code {
+    [Parameter]
+    public Order? Order { get; set; }
+    
+    /**
+     * This component is purely for user view and therefore allows
+     * no admin override
+     */
+    private bool CanEdit()
+    {
+        if (gs.Group == null) return false;
+        if (Order == null) return false;
+        switch (gs.Group.EditingRule)
+        {
+            case EditingRule.AllowBeforeDeadline:
+                return !IsOrderingClosed();
+            case EditingRule.AllowBeforeCartAndDeadline:
+                return !IsOrderingClosed() && Order.AddedToCart == false;
+            case EditingRule.AllowBeforeCartAndPaymentAndDeadline:
+                return !IsOrderingClosed() &&
+                       Order.AddedToCart == false &&
+                       Order.PaymentStatus != PaymentStatus.PaymentPending &&
+                       Order.PaymentStatus != PaymentStatus.Paid;
+            case EditingRule.AskEverytime:
+                return false; //TODO
+            case EditingRule.NeverAllow:
+                return false;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+    private bool IsOrderingClosed()
+    {
+        return DateTime.Now > gs.Group!.ClosingTime;
+    }
+
+    private void Delete()
+    {
+        if (CanEdit() && Order != null)
+        {
+            gs.ReloadRestriction.WaitOne();
+            gs.DeleteOrder(Order);
+            gs.Save();
+            gs.ReloadRestriction.Release();
+        }
+    }
+}

--- a/Components/Pages/CreateGroup.razor
+++ b/Components/Pages/CreateGroup.razor
@@ -90,6 +90,23 @@
                 </div>
             }
             <div class="col-sm-12 col-lg-5 offset-lg-3 mb-3">
+                <div class="form-floating">
+                    <InputSelect id="editing_rule" class="form-select form-control" @bind-Value="@Model.EditingRule">
+                        <option value="@EditingRule.NeverAllow">Never (only Group Leader can edit)</option>
+                        @if (Model!.PaymentType == PaymentType.PAY)
+                        {
+                            <option value="@EditingRule.AllowBeforeCartAndPaymentAndDeadline">If not in Cart, not paid and before Closing Time</option>
+                        }
+                        else
+                        {
+                            <option value="@EditingRule.AllowBeforeCartAndDeadline">If not in Cart and before Closing Time</option>
+                        }
+                        <option value="@EditingRule.AllowBeforeDeadline">If before Closing Time (not recommended, causes side effects)</option>
+                    </InputSelect>
+                    <label for="payment_type">Allow edits:</label>
+                </div>
+            </div>
+            <div class="col-sm-12 col-lg-5 offset-lg-3 mb-3">
                 <div>
                     <ValidationMessage For="() => Model!"/>
                 </div>
@@ -110,7 +127,8 @@
     {
         Model ??= new()
         {
-            ClosingTime = DateTime.Now + TimeSpan.FromMinutes(30)
+            ClosingTime = DateTime.Now + TimeSpan.FromMinutes(30),
+            EditingRule = EditingRule.NeverAllow
         };
         
         _editContext = new(Model);
@@ -157,6 +175,16 @@
         if (Model!.MenuURL != null && !Uri.IsWellFormedUriString(Model!.MenuURL, UriKind.Absolute))
         {
             _messageStore?.Add(() => Model!, "Please enter no or a valid url.");
+        }
+        
+        if (Model!.EditingRule == EditingRule.AllowBeforeCartAndDeadline && Model!.PaymentType == PaymentType.PAY)
+        {
+            _messageStore?.Add(() => Model!, "Please select a valid Editing Rule.");
+        }
+        
+        if (Model!.EditingRule == EditingRule.AllowBeforeCartAndPaymentAndDeadline && Model!.PaymentType != PaymentType.PAY)
+        {
+            _messageStore?.Add(() => Model!, "Please select a valid Editing Rule.");
         }
     }
 

--- a/Components/Pages/GroupOverview.razor
+++ b/Components/Pages/GroupOverview.razor
@@ -116,7 +116,10 @@
                 <td>
                     @if (adminService.IsAdmin())
                     {
-                        <span class="btn" title="Delete order" style="cursor: pointer" @onclick="() => Delete(order)">🗑</span>
+                        <span class="btn" title="Delete order" style="cursor: pointer" @onclick="() => Delete(order)"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" class="bi bi-trash" viewBox="0 0 16 16">
+                           <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0z"/>
+                           <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4zM2.5 3h11V2h-11z"/>
+                        </svg></span>
                     }
                 </td>
             </tr>

--- a/Components/Pages/MyOrder.razor
+++ b/Components/Pages/MyOrder.razor
@@ -6,6 +6,7 @@
 @using GroupOrder.Data
 @using GroupOrder.Services.Common
 @using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
+@using GroupOrder.Components.MyOrder
 @rendermode InteractiveServer
 
 @layout AppLayout
@@ -85,7 +86,9 @@
                                             @order.GetPrice()€
                                         </td>
                                     }
-                                    <td></td>
+                                    <td>
+                                        <DeleteOrder Order="@order"/>
+                                    </td>
                                 </tr>
                             }
                         }
@@ -106,7 +109,12 @@
                                             @order.GetPrice()€
                                         </td>
                                     }
-                                    <td></td>
+                                    <td>
+                                        @if (order.Person == gs.GetPersonByID(_personId.Value))
+                                        {
+                                            <DeleteOrder Order="@order"/>
+                                        }
+                                    </td>
                                 </tr>
                             }
                         }

--- a/Components/Pages/VanityURL.razor
+++ b/Components/Pages/VanityURL.razor
@@ -104,6 +104,23 @@
                         </div>
                     </div>
                     <div class="col-sm-12 col-lg-5 offset-lg-3 mb-3">
+                        <div class="form-floating">
+                            <InputSelect id="editing_rule" class="form-select form-control" @bind-Value="@Model.EditingRule">
+                                <option value="@EditingRule.NeverAllow">Never (only Group Leader can edit)</option>
+                                @if (Model!.PaymentType == PaymentType.PAY)
+                                {
+                                    <option value="@EditingRule.AllowBeforeCartAndPaymentAndDeadline">If not in Cart, not paid and before Closing Time</option>
+                                }
+                                else
+                                {
+                                    <option value="@EditingRule.AllowBeforeCartAndDeadline">If not in Cart and before Closing Time</option>
+                                }
+                                <option value="@EditingRule.AllowBeforeDeadline">If before Closing Time (not recommended, causes side effects)</option>
+                            </InputSelect>
+                            <label for="payment_type">Allow edits:</label>
+                        </div>
+                    </div>
+                    <div class="col-sm-12 col-lg-5 offset-lg-3 mb-3">
                         <div>
                             <ValidationMessage For="() => Model!"/>
                         </div>
@@ -169,7 +186,8 @@ else
     {
         Model ??= new()
         {
-            ClosingTime = DateTime.Now + TimeSpan.FromMinutes(30)
+            ClosingTime = DateTime.Now + TimeSpan.FromMinutes(30),
+            EditingRule = EditingRule.NeverAllow
         };
         
         _editContext = new(Model);
@@ -269,6 +287,16 @@ else
         if (Model!.MenuURL != null && !Uri.IsWellFormedUriString(Model!.MenuURL, UriKind.Absolute))
         {
             _messageStore?.Add(() => Model!, "Please enter no or a valid url.");
+        }
+
+        if (Model!.EditingRule == EditingRule.AllowBeforeCartAndDeadline && Model!.PaymentType == PaymentType.PAY)
+        {
+            _messageStore?.Add(() => Model!, "Please select a valid Editing Rule.");
+        }
+        
+        if (Model!.EditingRule == EditingRule.AllowBeforeCartAndPaymentAndDeadline && Model!.PaymentType != PaymentType.PAY)
+        {
+            _messageStore?.Add(() => Model!, "Please select a valid Editing Rule.");
         }
     }
 

--- a/Data/Group.cs
+++ b/Data/Group.cs
@@ -41,10 +41,22 @@ public class Group
     [DefaultValue(PaymentType.PAY)]
     public PaymentType PaymentType { get; set; }
     
+    [Required]
+    [DefaultValue(Data.EditingRule.NeverAllow)]
+    public EditingRule EditingRule { get; set; }
+    
 }
 
 public enum PaymentType {
     PAY,
     NO_NEED_TO_PAY,
     NO_PRICES
+}
+
+public enum EditingRule {
+    AllowBeforeDeadline,
+    AllowBeforeCartAndDeadline,
+    AllowBeforeCartAndPaymentAndDeadline,
+    AskEverytime, //TODO implement pending deletes
+    NeverAllow
 }

--- a/Migrations/20241215155212_Add editing rules.Designer.cs
+++ b/Migrations/20241215155212_Add editing rules.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GroupOrder.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GroupOrder.Migrations
 {
     [DbContext(typeof(GroupContext))]
-    partial class GroupContextModelSnapshot : ModelSnapshot
+    [Migration("20241215155212_Add editing rules")]
+    partial class Addeditingrules
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.8");

--- a/Migrations/20241215155212_Add editing rules.cs
+++ b/Migrations/20241215155212_Add editing rules.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GroupOrder.Migrations
+{
+    /// <inheritdoc />
+    public partial class Addeditingrules : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "EditingRule",
+                table: "Groups",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EditingRule",
+                table: "Groups");
+        }
+    }
+}


### PR DESCRIPTION
Closes #6 

This tries to implement one of the most requested features in a semi-sane way.
Editing might always cause unintended side effects.
By restricting when it is possible to delete orders, this might be somewhat less bad.

One of the things that bothers me most is that the payment status is currently associated with an order.
This means that if you delete a paid order (only possible with not recommended settings) and add an order of the same price, it will request the money again.
This might be something that needs to be reworked by moving the paid money into a `paidMoney` variable on the person object (but this would bring other problems).
Alternatively, an order with negative amount of the deleted order could be added. This could be an easy fix, but a bit ugly